### PR TITLE
Add a formula for ld-find-code-refs

### DIFF
--- a/Formula/ld-find-code-refs.rb
+++ b/Formula/ld-find-code-refs.rb
@@ -1,0 +1,16 @@
+# Documentation: https://docs.brew.sh/Formula-Cookbook
+#                https://www.rubydoc.info/github/Homebrew/brew/master/Formula
+class LdFindCodeRefs < Formula
+  desc "Enables you to keep track of feature flag usage in your code from LaunchDarkly."
+  homepage "https://launchdarkly.com/"
+  url "https://github.com/launchdarkly/ld-find-code-refs/releases/download/0.2.0/ld-find-code-refs_0.2.0_darwin_amd64.tar.gz"
+  sha256 "bc900537a491d40f783bb0dd81ab5373682683e49e41af4bf88014eb4067a882"
+  version "0.2.0"
+
+  depends_on "ag"
+
+  def install
+    # links the binary into /usr/local/bin
+    bin.install "ld-find-code-refs"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+LaunchDarkly's homebrew tap.
+
+## Installation
+
+```shell
+brew tap launchdarkly/tap
+```
+
+You can now brew install Launchdarkly formulae.
+
+Example:
+```shell
+brew install ld-find-code-refs
+```


### PR DESCRIPTION
The release tarball is downloaded from https://github.com/launchdarkly/ld-find-code-refs/releases . Another option would be to fetch the git repo and compile it on the user's machine, but that would require `go` to be installed. Downloading a pre-compiled binary seems like the way to go.

This formula was created by hand, but in the future we will automate updating it with goreleaser. 
Additionally, we have an action item to implement a `test` block for this formula but this first release will not have one.

What `brew install` looks like if you don't have `ag`:

```
$ brew install ld-find-code-refs
==> Installing ld-find-code-refs from launchdarkly/tap
==> Installing dependencies for launchdarkly/tap/ld-find-code-refs: ag
==> Installing launchdarkly/tap/ld-find-code-refs dependency: ag
==> Downloading https://homebrew.bintray.com/bottles/the_silver_searcher-2.2.0.mojave.bottle.tar.gz
Already downloaded: /Users/victor/Library/Caches/Homebrew/downloads/02a26479aa6fafac04465623fa5ee691ffafcaf4a7c5ab5aaa177994780089d6--the_silver_searcher-2.2.0.mojave.bottle.tar.gz
==> Pouring the_silver_searcher-2.2.0.mojave.bottle.tar.gz
==> Caveats
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
==> Summary
🍺  /usr/local/Cellar/the_silver_searcher/2.2.0: 10 files, 117.6KB
==> Installing launchdarkly/tap/ld-find-code-refs
==> Downloading https://github.com/launchdarkly/ld-find-code-refs/releases/download/0.2.0/ld-find-code-refs_0.2.0_darwin_amd64.tar.gz
Already downloaded: /Users/victor/Library/Caches/Homebrew/downloads/8ba5413b7741b196a6d68a68449b86211cd7110f79d74927a0db27110cb796f1--ld-find-code-refs_0.2.0_darwin_amd64.tar.gz
🍺  /usr/local/Cellar/ld-find-code-refs/0.2.0: 6 files, 5.6MB, built in 2 seconds
==> Caveats
==> the_silver_searcher
Bash completion has been installed to:
  /usr/local/etc/bash_completion.d

zsh completions have been installed to:
  /usr/local/share/zsh/site-functions
```

`brew info`:
```
$ brew info ld-find-code-refs
launchdarkly/tap/ld-find-code-refs: stable 0.2.0
Enables you to keep track of feature flag usage in your code from LaunchDarkly.
https://launchdarkly.com/
/usr/local/Cellar/ld-find-code-refs/0.2.0 (6 files, 5.6MB) *
  Built from source on 2019-01-16 at 17:48:55
From: https://github.com/launchdarkly/homebrew-tap/blob/master/Formula/ld-find-code-refs.rb
==> Dependencies
Required: ag ✔
```