### PR TITLE
Bump ld-find-code-refs to 0.4.0

### DIFF
--- a/Formula/ld-find-code-refs.rb
+++ b/Formula/ld-find-code-refs.rb
@@ -3,9 +3,9 @@
 class LdFindCodeRefs < Formula
   desc "Enables you to keep track of feature flag usage in your code from LaunchDarkly."
   homepage "https://launchdarkly.com/"
-  url "https://github.com/launchdarkly/ld-find-code-refs/releases/download/0.3.0/ld-find-code-refs_0.3.0_darwin_amd64.tar.gz"
-  sha256 "1f010cb846ed26af60efdc937297ef4b346326d6342c22a5798acd6d1226c03c"
-  version "0.3.0"
+  url "https://github.com/launchdarkly/ld-find-code-refs/releases/download/0.4.0/ld-find-code-refs_0.4.0_darwin_amd64.tar.gz"
+  sha256 "599f81e9730e8425f8266c8bee2614e56d1340e25e5d233612c3f7247325457f"
+  version "0.4.0"
 
   depends_on "ag"
 


### PR DESCRIPTION
sha computed with `curl -L https://github.com/launchdarkly/ld-find-code-refs/releases/download/0.4.0/ld-find-code-refs_0.4.0_linux_amd64.tar.gz | openssl sha256`