### PR TITLE
Update ld-find-code-refs.rb

### DIFF
--- a/Formula/ld-find-code-refs.rb
+++ b/Formula/ld-find-code-refs.rb
@@ -3,7 +3,6 @@ class LdFindCodeRefs < Formula
   desc "Job for finding and sending feature flag code references to LaunchDarkly"
   homepage "https://launchdarkly.com"
   version "2.2.3"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/launchdarkly/ld-find-code-refs/releases/download/2.2.3/ld-find-code-refs_2.2.3_darwin_amd64.tar.gz"


### PR DESCRIPTION
Homebrew shows a warning about the use of this deprecated feature. This PR removes it as suggested in the warning:

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the launchdarkly/tap tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/launchdarkly/homebrew-tap/Formula/ld-find-code-refs.rb:6
```

Closes #9